### PR TITLE
Add materials and batches API with SQLAlchemy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+*.db

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Digitalizacion Fabrica API
+
+Ejemplos de uso para los endpoints de **materials** y **batches**.
+
+## Materials
+
+```bash
+# Crear material
+curl -X POST http://localhost:8000/materials \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Acero", "description": "Material base"}'
+
+# Listar materiales
+curl http://localhost:8000/materials
+
+# Soft delete de un material
+curl -X DELETE http://localhost:8000/materials/<material_id>
+```
+
+## Batches
+
+```bash
+# Crear batch
+curl -X POST http://localhost:8000/batches \
+  -H "Content-Type: application/json" \
+  -d '{"material_id": "<material_id>", "batch_code": "Lote1", "quantity": 100, "production_date": "2024-01-01"}'
+
+# Listar batches filtrando por material
+curl http://localhost:8000/batches?material_id=<material_id>
+
+# Soft delete de un batch
+curl -X DELETE http://localhost:8000/batches/<batch_id>
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,16 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DB_URL = os.getenv('DB_URL', 'sqlite:///./app.db')
+connect_args = {'check_same_thread': False} if DB_URL.startswith('sqlite') else {}
+engine = create_engine(DB_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,1 @@
+"""API routers package."""

--- a/app/routers/batches.py
+++ b/app/routers/batches.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import date
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("", response_model=schemas.BatchRead, status_code=201)
+def create_batch(batch: schemas.BatchCreate, db: Session = Depends(get_db)):
+    obj = models.Batch(**batch.model_dump())
+    db.add(obj)
+    try:
+        db.commit()
+        db.refresh(obj)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch already exists")
+    return obj
+
+
+@router.get("", response_model=list[schemas.BatchRead])
+def list_batches(
+    db: Session = Depends(get_db),
+    material_id: str | None = Query(None),
+    batch_code: str | None = Query(None),
+    date_from: date | None = Query(None),
+    date_to: date | None = Query(None),
+    is_active: bool | None = Query(True),
+):
+    q = db.query(models.Batch)
+    if material_id:
+        q = q.filter(models.Batch.material_id == material_id)
+    if batch_code:
+        q = q.filter(models.Batch.batch_code == batch_code)
+    if date_from:
+        q = q.filter(models.Batch.production_date >= date_from)
+    if date_to:
+        q = q.filter(models.Batch.production_date <= date_to)
+    if is_active is not None:
+        q = q.filter(models.Batch.is_active == is_active)
+    return q.order_by(models.Batch.production_date.desc()).all()
+
+
+@router.get("/{batch_id}", response_model=schemas.BatchRead)
+def get_batch(batch_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    return obj
+
+
+@router.put("/{batch_id}", response_model=schemas.BatchRead)
+def update_batch(batch_id: str, batch_in: schemas.BatchUpdate, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    for key, value in batch_in.model_dump(exclude_unset=True).items():
+        setattr(obj, key, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch already exists")
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{batch_id}", status_code=204)
+def delete_batch(batch_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    obj.is_active = False
+    db.commit()
+    return None

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("", response_model=schemas.MaterialRead, status_code=201)
+def create_material(material: schemas.MaterialCreate, db: Session = Depends(get_db)):
+    obj = models.Material(**material.model_dump())
+    db.add(obj)
+    try:
+        db.commit()
+        db.refresh(obj)
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name already exists")
+    return obj
+
+
+@router.get("", response_model=list[schemas.MaterialRead])
+def list_materials(
+    db: Session = Depends(get_db),
+    search: str | None = Query(None, description="Search by name"),
+    is_active: bool | None = Query(True, description="Filter by active flag"),
+):
+    q = db.query(models.Material)
+    if search:
+        q = q.filter(models.Material.name.ilike(f"%{search}%"))
+    if is_active is not None:
+        q = q.filter(models.Material.is_active == is_active)
+    return q.order_by(models.Material.name).all()
+
+
+@router.get("/{material_id}", response_model=schemas.MaterialRead)
+def get_material(material_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Material, material_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Material not found")
+    return obj
+
+
+@router.put("/{material_id}", response_model=schemas.MaterialRead)
+def update_material(
+    material_id: str,
+    material_in: schemas.MaterialUpdate,
+    db: Session = Depends(get_db),
+):
+    obj = db.get(models.Material, material_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Material not found")
+    for key, value in material_in.model_dump(exclude_unset=True).items():
+        setattr(obj, key, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name already exists")
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{material_id}", status_code=204)
+def delete_material(material_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Material, material_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Material not found")
+    obj.is_active = False
+    db.commit()
+    return None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -62,3 +62,61 @@ class DocumentList(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Material Schemas
+# ---------------------------------------------------------------------
+
+
+class MaterialCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    is_active: bool = True
+
+
+class MaterialRead(MaterialCreate):
+    id: str
+
+    class Config:
+        from_attributes = True
+
+
+class MaterialUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Batch Schemas
+# ---------------------------------------------------------------------
+
+
+class BatchCreate(BaseModel):
+    material_id: str
+    batch_code: str
+    quantity: int
+    production_date: date
+    is_active: bool = True
+
+
+class BatchRead(BatchCreate):
+    id: str
+
+    class Config:
+        from_attributes = True
+
+
+class BatchUpdate(BaseModel):
+    material_id: Optional[str] = None
+    batch_code: Optional[str] = None
+    quantity: Optional[int] = None
+    production_date: Optional[date] = None
+    is_active: Optional[bool] = None
+
+    class Config:
+        from_attributes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ uvicorn[standard]==0.30.1
 python-multipart==0.0.9
 pydantic==2.7.4
 supabase==2.4.6
+SQLAlchemy==2.0.29
+alembic==1.13.1

--- a/tests/test_materials_batches.py
+++ b/tests/test_materials_batches.py
@@ -1,0 +1,116 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.database import Base, get_db
+from app.main import app
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_url = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(db_url, connect_args={"check_same_thread": False})
+    TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(bind=engine)
+    session = TestingSessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def client(db_session):
+    app.dependency_overrides[get_db] = lambda: db_session
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+def test_create_and_filter_batch(client):
+    # Create material
+    res = client.post("/materials", json={"name": "Steel"})
+    assert res.status_code == 201
+    material_id = res.json()["id"]
+
+    # Create batch
+    res = client.post(
+        "/batches",
+        json={
+            "material_id": material_id,
+            "batch_code": "B1",
+            "quantity": 5,
+            "production_date": "2024-01-01",
+        },
+    )
+    assert res.status_code == 201
+
+    # List batches filtered by material_id
+    res = client.get(f"/batches?material_id={material_id}")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["batch_code"] == "B1"
+
+
+def test_duplicates(client):
+    res = client.post("/materials", json={"name": "Iron"})
+    assert res.status_code == 201
+    material_id = res.json()["id"]
+
+    # Duplicate material
+    res = client.post("/materials", json={"name": "Iron"})
+    assert res.status_code == 409
+
+    # Batch unique per (material_id, batch_code)
+    res = client.post(
+        "/batches",
+        json={
+            "material_id": material_id,
+            "batch_code": "X1",
+            "quantity": 1,
+            "production_date": "2024-01-02",
+        },
+    )
+    assert res.status_code == 201
+
+    res = client.post(
+        "/batches",
+        json={
+            "material_id": material_id,
+            "batch_code": "X1",
+            "quantity": 2,
+            "production_date": "2024-01-03",
+        },
+    )
+    assert res.status_code == 409
+
+
+def test_soft_delete(client):
+    # Material
+    res = client.post("/materials", json={"name": "Copper"})
+    material_id = res.json()["id"]
+    del_res = client.delete(f"/materials/{material_id}")
+    assert del_res.status_code == 204
+    res = client.get("/materials")
+    ids = [m["id"] for m in res.json()]
+    assert material_id not in ids
+
+    # Batch
+    res_mat = client.post("/materials", json={"name": "Aluminium"})
+    mat_id = res_mat.json()["id"]
+    res_batch = client.post(
+        "/batches",
+        json={
+            "material_id": mat_id,
+            "batch_code": "B-1",
+            "quantity": 3,
+            "production_date": "2024-01-04",
+        },
+    )
+    batch_id = res_batch.json()["id"]
+    del_res = client.delete(f"/batches/{batch_id}")
+    assert del_res.status_code == 204
+    res = client.get(f"/batches?material_id={mat_id}")
+    assert res.json() == []


### PR DESCRIPTION
## Summary
- add Material and Batch models and routers with soft delete and filters
- create database setup for SQLite/Postgres and include routers in main app
- document curl usage and provide pytest suite for materials and batches

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.111.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_68b4b500a214832d99dbe6d268ab7211