### PR TITLE
Add materials and batches endpoints with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Digitalizacion Fabrica API
+
+## Materials
+```bash
+curl -X POST http://localhost:8000/materials \
+     -H 'Content-Type: application/json' \
+     -d '{"name": "Acero", "description": "metal"}'
+
+curl 'http://localhost:8000/materials?search=ac'
+```
+
+## Batches
+```bash
+curl -X POST http://localhost:8000/batches \
+     -H 'Content-Type: application/json' \
+     -d '{"material_id": "<MATERIAL_ID>", "batch_code": "L001", "quantity": 10, "production_date": "2024-01-01"}'
+
+curl 'http://localhost:8000/batches?material_id=<MATERIAL_ID>'
+```

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,33 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+
+Base = declarative_base()
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+# Try to run migrations; if it fails, create tables directly
+try:
+    from alembic import command
+    from alembic.config import Config
+    import pathlib
+
+    BASE_DIR = pathlib.Path(__file__).resolve().parent
+    alembic_cfg = Config(str(BASE_DIR.parent / "alembic.ini"))
+    command.upgrade(alembic_cfg, "head")
+except Exception:
+    Base.metadata.create_all(bind=engine)

--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ import hashlib, json, re, uuid
 
 from supabase import create_client, Client
 from app.config import settings
+from app.routers import materials, batches
 
 # --------------------
 # App & CORS
@@ -22,6 +23,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(materials.router, prefix="/materials", tags=["materials"])
+app.include_router(batches.router, prefix="/batches", tags=["batches"])
 
 # --------------------
 # Supabase client

--- a/app/routers/batches.py
+++ b/app/routers/batches.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("", response_model=schemas.BatchRead, status_code=201)
+def create_batch(batch: schemas.BatchCreate, db: Session = Depends(get_db)):
+    obj = models.Batch(**batch.model_dump())
+    db.add(obj)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch already exists")
+    db.refresh(obj)
+    return obj
+
+
+@router.get("", response_model=list[schemas.BatchRead])
+def list_batches(
+    material_id: UUID | None = None,
+    batch_code: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    q = db.query(models.Batch)
+    if material_id:
+        q = q.filter(models.Batch.material_id == material_id)
+    if batch_code:
+        q = q.filter(models.Batch.batch_code == batch_code)
+    if date_from:
+        q = q.filter(models.Batch.production_date >= date_from)
+    if date_to:
+        q = q.filter(models.Batch.production_date <= date_to)
+    return (
+        q.order_by(models.Batch.production_date.desc(), models.Batch.id.desc())
+        .limit(limit)
+        .offset(offset)
+        .all()
+    )
+
+
+@router.get("/{batch_id}", response_model=schemas.BatchRead)
+def get_batch(batch_id: UUID, db: Session = Depends(get_db)):
+    obj = db.query(models.Batch).filter(models.Batch.id == batch_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    return obj
+
+
+@router.patch("/{batch_id}", response_model=schemas.BatchRead)
+def update_batch(
+    batch_id: UUID,
+    batch_up: schemas.BatchUpdate,
+    db: Session = Depends(get_db),
+):
+    obj = db.query(models.Batch).filter(models.Batch.id == batch_id).first()
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    for field, value in batch_up.model_dump(exclude_unset=True).items():
+        setattr(obj, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch already exists")
+    db.refresh(obj)
+    return obj

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("", response_model=schemas.MaterialRead, status_code=201)
+def create_material(
+    material: schemas.MaterialCreate, db: Session = Depends(get_db)
+):
+    mat = models.Material(**material.model_dump())
+    db.add(mat)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name already exists")
+    db.refresh(mat)
+    return mat
+
+
+@router.get("", response_model=list[schemas.MaterialRead])
+def list_materials(
+    search: str | None = None,
+    limit: int = Query(20, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    db: Session = Depends(get_db),
+):
+    q = db.query(models.Material)
+    if search:
+        q = q.filter(models.Material.name.ilike(f"%{search}%"))
+    return q.order_by(models.Material.name).limit(limit).offset(offset).all()
+
+
+@router.get("/{material_id}", response_model=schemas.MaterialRead)
+def get_material(material_id: UUID, db: Session = Depends(get_db)):
+    mat = db.query(models.Material).filter(models.Material.id == material_id).first()
+    if not mat:
+        raise HTTPException(status_code=404, detail="Material not found")
+    return mat
+
+
+@router.patch("/{material_id}", response_model=schemas.MaterialRead)
+def update_material(
+    material_id: UUID,
+    material_up: schemas.MaterialUpdate,
+    db: Session = Depends(get_db),
+):
+    mat = db.query(models.Material).filter(models.Material.id == material_id).first()
+    if not mat:
+        raise HTTPException(status_code=404, detail="Material not found")
+    for field, value in material_up.model_dump(exclude_unset=True).items():
+        setattr(mat, field, value)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name already exists")
+    db.refresh(mat)
+    return mat

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,7 +1,7 @@
 # app/schemas.py
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
@@ -59,6 +59,67 @@ class DocumentList(BaseModel):
     """
     items: List[DocumentOut]
     total: int
+
+    class Config:
+        from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Material Schemas
+# ---------------------------------------------------------------------
+
+class MaterialCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+
+
+class MaterialRead(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str] = None
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class MaterialUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+
+    class Config:
+        from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Batch Schemas
+# ---------------------------------------------------------------------
+
+class BatchCreate(BaseModel):
+    material_id: UUID
+    batch_code: str
+    quantity: int = Field(ge=0)
+    production_date: date
+
+
+class BatchRead(BaseModel):
+    id: UUID
+    material_id: UUID
+    batch_code: str
+    quantity: int
+    production_date: date
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class BatchUpdate(BaseModel):
+    batch_code: Optional[str] = None
+    quantity: Optional[int] = Field(default=None, ge=0)
+    production_date: Optional[date] = None
 
     class Config:
         from_attributes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.1
 python-multipart==0.0.9
 pydantic==2.7.4
 supabase==2.4.6
+SQLAlchemy==2.0.30

--- a/tests/test_materials_batches.py
+++ b/tests/test_materials_batches.py
@@ -1,0 +1,66 @@
+import os
+from datetime import date
+
+import pytest
+from fastapi.testclient import TestClient
+
+# Configurar base de datos en memoria antes de importar la app
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+from app.main import app  # noqa: E402
+from app.database import Base, engine  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def test_create_material_and_batch(client):
+    res = client.post("/materials", json={"name": "Acero"})
+    assert res.status_code == 201
+    mat_id = res.json()["id"]
+
+    batch_payload = {
+        "material_id": mat_id,
+        "batch_code": "L001",
+        "quantity": 10,
+        "production_date": "2024-01-01",
+    }
+    res = client.post("/batches", json=batch_payload)
+    assert res.status_code == 201
+
+    res = client.get(f"/batches?material_id={mat_id}")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["batch_code"] == "L001"
+
+
+def test_duplicate_material_name(client):
+    client.post("/materials", json={"name": "M1"})
+    res = client.post("/materials", json={"name": "M1"})
+    assert res.status_code == 409
+
+
+def test_duplicate_batch(client):
+    res = client.post("/materials", json={"name": "Mat"})
+    mat_id = res.json()["id"]
+    payload = {
+        "material_id": mat_id,
+        "batch_code": "B1",
+        "quantity": 5,
+        "production_date": "2024-01-01",
+    }
+    res = client.post("/batches", json=payload)
+    assert res.status_code == 201
+    res = client.post("/batches", json=payload)
+    assert res.status_code == 409


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and Pydantic schemas for materials and batches
- expose `/materials` and `/batches` FastAPI routers
- include database session and example usage in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b4b825be94832d89642095b879420f