### PR TITLE
feat: add materials and batches API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.venv/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# Digitalizacion Fabrica API
+
+Ejemplos de uso para los nuevos endpoints `materials` y `batches`.
+
+## Materials
+```bash
+# Crear material
+curl -X POST http://localhost:8000/materials/ \
+  -H "Content-Type: application/json" \
+  -d '{"name":"Steel","description":"Acero"}'
+
+# Listar materiales activos
+curl http://localhost:8000/materials/
+
+# Soft delete de un material
+curl -X DELETE http://localhost:8000/materials/<material_id>
+```
+
+## Batches
+```bash
+# Crear batch
+curl -X POST http://localhost:8000/batches/ \
+  -H "Content-Type: application/json" \
+  -d '{"material_id":"<material_id>","batch_code":"B001","quantity":10,"production_date":"2024-01-01"}'
+
+# Listar batches por material
+curl "http://localhost:8000/batches?material_id=<material_id>"
+
+# Soft delete de un batch
+curl -X DELETE http://localhost:8000/batches/<batch_id>
+```

--- a/app/config.py
+++ b/app/config.py
@@ -5,5 +5,6 @@ class Settings:
     SUPABASE_SERVICE_ROLE: str = os.getenv("SUPABASE_SERVICE_ROLE", "")
     SUPABASE_BUCKET: str = os.getenv("SUPABASE_BUCKET", "traza-docs")
     ALLOW_ORIGINS: str = os.getenv("ALLOW_ORIGINS", "*")
+    SUPABASE_ENABLED: bool = os.getenv("SUPABASE_ENABLED", "true").lower() == "true"
 
 settings = Settings()

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,21 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./app.db")
+
+connect_args = {}
+if DATABASE_URL.startswith("sqlite"):
+    connect_args["check_same_thread"] = False
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/app/routers/batches.py
+++ b/app/routers/batches.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import date
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("/", response_model=schemas.BatchRead, status_code=201)
+def create_batch(batch: schemas.BatchCreate, db: Session = Depends(get_db)):
+    obj = models.Batch(**batch.model_dump())
+    db.add(obj)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch duplicado")
+    db.refresh(obj)
+    return obj
+
+
+@router.get("/{batch_id}", response_model=schemas.BatchRead)
+def get_batch(batch_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch no encontrado")
+    return obj
+
+
+@router.get("/", response_model=list[schemas.BatchRead])
+def list_batches(
+    db: Session = Depends(get_db),
+    material_id: str | None = Query(None),
+    batch_code: str | None = Query(None),
+    production_date_from: date | None = Query(None),
+    production_date_to: date | None = Query(None),
+    is_active: bool | None = Query(True),
+):
+    q = db.query(models.Batch)
+    if material_id:
+        q = q.filter(models.Batch.material_id == material_id)
+    if batch_code:
+        q = q.filter(func.lower(models.Batch.batch_code).like(f"%{batch_code.lower()}%"))
+    if production_date_from:
+        q = q.filter(models.Batch.production_date >= production_date_from)
+    if production_date_to:
+        q = q.filter(models.Batch.production_date <= production_date_to)
+    if is_active is not None:
+        q = q.filter(models.Batch.is_active == is_active)
+    return q.order_by(models.Batch.production_date.desc()).all()
+
+
+@router.put("/{batch_id}", response_model=schemas.BatchRead)
+def update_batch(batch_id: str, payload: schemas.BatchUpdate, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Batch no encontrado")
+    for k, v in payload.model_dump(exclude_unset=True).items():
+        setattr(obj, k, v)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Batch duplicado")
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{batch_id}", status_code=204)
+def delete_batch(batch_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Batch, batch_id)
+    if not obj or not obj.is_active:
+        raise HTTPException(status_code=404, detail="Batch no encontrado")
+    obj.is_active = False
+    db.commit()
+    return None

--- a/app/routers/materials.py
+++ b/app/routers/materials.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, or_
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app import models, schemas
+
+router = APIRouter()
+
+
+@router.post("/", response_model=schemas.MaterialRead, status_code=201)
+def create_material(material: schemas.MaterialCreate, db: Session = Depends(get_db)):
+    obj = models.Material(**material.model_dump())
+    db.add(obj)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name duplicado")
+    db.refresh(obj)
+    return obj
+
+
+@router.get("/{material_id}", response_model=schemas.MaterialRead)
+def get_material(material_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Material, material_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Material no encontrado")
+    return obj
+
+
+@router.get("/", response_model=list[schemas.MaterialRead])
+def list_materials(
+    db: Session = Depends(get_db),
+    search: str | None = Query(None, description="Filtro por nombre/descripcion"),
+    is_active: bool | None = Query(True, description="Filtrar por activos"),
+):
+    q = db.query(models.Material)
+    if search:
+        pattern = f"%{search.lower()}%"
+        q = q.filter(
+            or_(
+                func.lower(models.Material.name).like(pattern),
+                func.lower(models.Material.description).like(pattern),
+            )
+        )
+    if is_active is not None:
+        q = q.filter(models.Material.is_active == is_active)
+    return q.order_by(models.Material.name).all()
+
+
+@router.put("/{material_id}", response_model=schemas.MaterialRead)
+def update_material(
+    material_id: str, payload: schemas.MaterialUpdate, db: Session = Depends(get_db)
+):
+    obj = db.get(models.Material, material_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Material no encontrado")
+    for k, v in payload.model_dump(exclude_unset=True).items():
+        setattr(obj, k, v)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="Material name duplicado")
+    db.refresh(obj)
+    return obj
+
+
+@router.delete("/{material_id}", status_code=204)
+def delete_material(material_id: str, db: Session = Depends(get_db)):
+    obj = db.get(models.Material, material_id)
+    if not obj or not obj.is_active:
+        raise HTTPException(status_code=404, detail="Material no encontrado")
+    obj.is_active = False
+    db.commit()
+    return None

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -62,3 +62,67 @@ class DocumentList(BaseModel):
 
     class Config:
         from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Material Schemas
+# ---------------------------------------------------------------------
+
+class MaterialBase(BaseModel):
+    name: str
+    description: Optional[str] = None
+    is_active: bool = True
+
+
+class MaterialCreate(MaterialBase):
+    pass
+
+
+class MaterialUpdate(BaseModel):
+    name: Optional[str] = None
+    description: Optional[str] = None
+    is_active: Optional[bool] = None
+
+    class Config:
+        from_attributes = True
+
+
+class MaterialRead(MaterialBase):
+    id: str
+
+    class Config:
+        from_attributes = True
+
+
+# ---------------------------------------------------------------------
+# Batch Schemas
+# ---------------------------------------------------------------------
+
+class BatchBase(BaseModel):
+    material_id: str
+    batch_code: str
+    quantity: int = Field(ge=0)
+    production_date: date
+    is_active: bool = True
+
+
+class BatchCreate(BatchBase):
+    pass
+
+
+class BatchUpdate(BaseModel):
+    material_id: Optional[str] = None
+    batch_code: Optional[str] = None
+    quantity: Optional[int] = Field(None, ge=0)
+    production_date: Optional[date] = None
+    is_active: Optional[bool] = None
+
+    class Config:
+        from_attributes = True
+
+
+class BatchRead(BatchBase):
+    id: str
+
+    class Config:
+        from_attributes = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.1
 python-multipart==0.0.9
 pydantic==2.7.4
 supabase==2.4.6
+sqlalchemy==2.0.30

--- a/tests/test_materials_batches.py
+++ b/tests/test_materials_batches.py
@@ -1,0 +1,69 @@
+import os
+from datetime import date
+
+# Ensure env vars before importing app
+os.environ.setdefault("SUPABASE_ENABLED", "false")
+os.environ.setdefault("DATABASE_URL", "sqlite:///./test.db")
+
+from fastapi.testclient import TestClient
+from app.main import app
+from app.database import Base, engine
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_db():
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    yield
+    Base.metadata.drop_all(bind=engine)
+
+
+client = TestClient(app)
+
+
+def test_materials_batches_flow():
+    # Crear material
+    resp = client.post("/materials/", json={"name": "Steel", "description": "A"})
+    assert resp.status_code == 201
+    mat = resp.json()
+    mat_id = mat["id"]
+
+    # Crear batch
+    payload = {
+        "material_id": mat_id,
+        "batch_code": "B001",
+        "quantity": 5,
+        "production_date": "2024-01-01",
+    }
+    resp = client.post("/batches/", json=payload)
+    assert resp.status_code == 201
+    batch = resp.json()
+
+    # Listar por material_id
+    resp = client.get(f"/batches/?material_id={mat_id}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) == 1
+
+    # Duplicados
+    resp = client.post("/materials/", json={"name": "Steel"})
+    assert resp.status_code == 409
+
+    resp = client.post("/batches/", json=payload)
+    assert resp.status_code == 409
+
+    # Soft delete batch
+    resp = client.delete(f"/batches/{batch['id']}")
+    assert resp.status_code == 204
+    resp = client.get(f"/batches/?material_id={mat_id}")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+    # Soft delete material
+    resp = client.delete(f"/materials/{mat_id}")
+    assert resp.status_code == 204
+    resp = client.get("/materials/")
+    assert resp.status_code == 200
+    assert resp.json() == []


### PR DESCRIPTION
## Summary
- add SQLAlchemy setup and models for materials and batches
- expose CRUD routers with search filters and soft delete
- make Supabase optional and ensure DB fallback when Alembic missing

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.111.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68b4ca7eb8e4832d9abf1a21489f18cf