### PR TITLE
Ensure DB tables created when Alembic is unavailable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -56,6 +56,8 @@ def startup_event() -> None:
         alembic_cfg = Config(os.path.join(os.path.dirname(__file__), "..", "alembic.ini"))
         command.upgrade(alembic_cfg, "head")
     except Exception:
+        # Alembic no está disponible o falló: creamos tablas directamente
+        import app.models  # noqa: F401 - asegura registro de modelos
         Base.metadata.create_all(bind=engine)
 
 


### PR DESCRIPTION
## Summary
- Fallback to `Base.metadata.create_all(bind=engine)` on startup when Alembic migrations fail
- Import `app.models` so metadata is registered for table creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: 403 Client Error: Forbidden for url: https://pypi.org/simple/fastapi/)*

------
https://chatgpt.com/codex/tasks/task_e_68b4cfe17484832da01669182dbb277a