### PR TITLE
feat: add robust DB startup fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,7 @@ curl -X DELETE http://localhost:8000/batches/<batch_id>
 
 ## Fallback de DB (sandbox)
 
-- En desarrollo/sandbox (SQLite) el servicio crea tablas automáticamente al arrancar.
+- En desarrollo/sandbox se usa SQLite y por defecto **no** se corren migraciones.
+- El servicio siempre crea tablas automáticamente al arrancar.
+- Si se desean forzar migraciones de Alembic, setear `RUN_MIGRATIONS=true`.
 - En producción se recomienda usar Alembic; el fallback es idempotente y seguro en ambos casos.

--- a/tests/test_db_fallback.py
+++ b/tests/test_db_fallback.py
@@ -1,23 +1,37 @@
 import os
+import importlib
 from fastapi.testclient import TestClient
 
-# Forzar SQLite en sandbox y desactivar supabase
+# Forzar SQLite en sandbox, desactivar supabase y migraciones
 os.environ.setdefault("DATABASE_URL", "sqlite:///./dev.db")
 os.environ.setdefault("SUPABASE_ENABLED", "false")
-
-from app.main import app
+os.environ.setdefault("RUN_MIGRATIONS", "false")
 
 
 def test_db_fallback_creates_tables_and_post_material_works():
-    # empezar con DB limpia
+    # empezar con DB limpia antes de importar la app
     try:
         os.remove("dev.db")
     except FileNotFoundError:
         pass
 
+    # Recargar módulos para tomar las nuevas variables
+    import app.database as database
+    import app.models as models
+    import app.main as main
+
+    importlib.reload(database)
+    importlib.reload(models)
+    importlib.reload(main)
+
+    app = main.app
+
     # usar TestClient para disparar eventos de startup
     with TestClient(app) as client:
-        r = client.post("/materials", json={"name": "Envase PET 500", "description": "botella 500 ml"})
+        r = client.post(
+            "/materials",
+            json={"name": "Envase PET 500", "description": "botella 500 ml"},
+        )
         assert r.status_code in (200, 201), r.text
         data = r.json()
         assert "id" in data and data["name"] == "Envase PET 500"


### PR DESCRIPTION
## Summary
- make Alembic migrations optional via `RUN_MIGRATIONS` and always run `create_all` on startup with `DB_FALLBACK_RAN` log
- document default SQLite usage and how to force migrations
- test that app starts with empty SQLite DB and `/materials` works without manual migrations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.111.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dae3ce54832d80934b1457be5bd5